### PR TITLE
Support "skip ranges"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ expansion. Expansion follows these rules:
      bracket. If no separator is supplied `", "` is assumed.
    - You can specify a custom range `i` should iterate through by placing a term of the form `<start>..<end>` between
      the starting `[` and `#` of an expansion. Either `start` or `end` can be omitted in which case the defaults are         assumed.
+   - You can specify a skipped range by placing a term of the form `!<start>..<end>` between the starting `[` and `#` 
+     of the expansion. Code with a skipped range will be omitted when the current `i` falls within that range.
  - Everywhere digit `1` is replaced by `i`, digit `0` is replaced by `i - 1`, and digit `2` is replaced by `i + 1`
    unless the digit is prefixed with `##`.
  - To encode the sharp `'#'` character precede it with a backslash e.g. `"\#"`.

--- a/src/main/scala/spray/boilerplate/Generator.scala
+++ b/src/main/scala/spray/boilerplate/Generator.scala
@@ -12,6 +12,7 @@ object Generator {
 
   def generate(format: TemplateElement)(idx: Int): String = format match {
     case Sequence(els @ _*)        ⇒ els.map(e ⇒ generate(e)(idx)).mkString
+    case Skip(inner, range)        ⇒ if (range.start.getOrElse(1) to range.end.getOrElse(idx) contains idx) "" else generate(inner)(idx)
     case Expand(inner, sep, range) ⇒ (range.start.getOrElse(1) to range.end.getOrElse(idx)).map(generate(inner)).mkString(sep)
     case Offset(i)                 ⇒ (idx + i - 1).toString
     case LiteralString(lit)        ⇒ lit

--- a/src/main/scala/spray/boilerplate/TemplateParser.scala
+++ b/src/main/scala/spray/boilerplate/TemplateParser.scala
@@ -21,6 +21,9 @@ case class Offset(i: Int) extends TemplateElement
 
 case class Range(start: Option[Int] = None, end: Option[Int] = None)
 
+/** A region to skip when expanding with a given range */
+case class Skip(inner: TemplateElement, range: Range) extends TemplateElement
+
 /** A region in which to apply expansions */
 case class Expand(
   inner: TemplateElement,
@@ -38,12 +41,12 @@ object TemplateParser extends RegexParsers {
   val EOI = 26.toChar
 
   lazy val elements: Parser[TemplateElement] = rep1(element) ^^ maybeSequence
-  lazy val element: Parser[TemplateElement] = offset | literalString | expand
+  lazy val element: Parser[TemplateElement] = offset | literalString | skip | expand
 
   lazy val offset: Parser[Offset] = offsetChars ^^ (s ⇒ Offset(s - '0'))
   lazy val literalString: Parser[LiteralString] = rep1(escapedSharp | escapedLiteralNumber | literalChar) ^^ (chs ⇒ LiteralString(chs.mkString))
   lazy val literalChar: Parser[Char] =
-    not(expandStart | """#[^\]]*\]""".r | offsetChars) ~> elem("Any character", _ != EOI)
+    not(skipStart | expandStart | """#[^\]]*\]""".r | offsetChars) ~> elem("Any character", _ != EOI)
 
   lazy val offsetChars: Parser[Char] = "[012]".r ^^ (_.head) | failure("'##' is used to quote '0', '1', or '2', use '\\#\\#' to output double hashes")
 
@@ -51,12 +54,17 @@ object TemplateParser extends RegexParsers {
   lazy val escapedLiteralNumber: Parser[Char] = "##" ~! offsetChars ^^ { case _ ~ x ⇒ x }
 
   lazy val outsideLiteralString: Parser[LiteralString] = rep1(escapedSharp | outsideLiteralChar) ^^ (chs ⇒ LiteralString(chs.mkString))
-  lazy val outsideLiteralChar: Parser[Char] = not(expandStart) ~> elem("Any character", _ != EOI)
+  lazy val outsideLiteralChar: Parser[Char] = not(skipStart | expandStart) ~> elem("Any character", _ != EOI)
 
   lazy val expand: Parser[Expand] = expandStart ~ elements ~ "#" ~ separatorChars <~ "]" ^^ {
     case range ~ els ~ x ~ sep ⇒ Expand(els, sep.getOrElse(Expand.defaultSeparator), range)
   }
   lazy val expandStart: Parser[Range] = "[" ~> range <~ "#"
+
+  lazy val skip: Parser[Skip] = skipStart ~ elements <~ "#]" ^^ {
+    case range ~ els ⇒ Skip(els, range)
+  }
+  lazy val skipStart: Parser[Range] = "[!" ~> range <~ "#"
 
   lazy val range: Parser[Range] =
     (opt("""\d{1,2}""".r) ~ """\s*\.\.\s*""".r ~ opt("""\d{1,2}""".r) ^^ {
@@ -64,7 +72,7 @@ object TemplateParser extends RegexParsers {
     }) | success(Range())
 
   lazy val outsideElements: Parser[TemplateElement] =
-    rep1(expand | outsideLiteralString) ^^ maybeSequence
+    rep1(skip | expand | outsideLiteralString) ^^ maybeSequence
 
   lazy val separatorChars: Parser[Option[String]] = rep("""[^\]]""".r) ^^ (_.reduceLeftOption(_ + _))
 

--- a/src/test/scala/spray/boilerplate/GeneratorSpecs.scala
+++ b/src/test/scala/spray/boilerplate/GeneratorSpecs.scala
@@ -46,6 +46,12 @@ class GeneratorSpecs extends Specification {
     "support inner custom range" in {
       gen4("[#a1([2..#T1#])#]") === "a1(), a2(T2), a3(T2, T3), a4(T2, T3, T4)"
     }
+    "skip inner range" in {
+      gen4("[#a1([!2..3#T1#])#]") === "a1(T1), a2(), a3(), a4(T4)"
+    }
+    "skip with inner expansion" in {
+      gen4("[#a1([!4..#[1..#T1#]#])#]") === "a1(T1), a2(T1, T2), a3(T1, T2, T3), a4()"
+    }
   }
 
   def gen4(template: String): String = Generator.generateFromTemplate(template, 4)

--- a/src/test/scala/spray/boilerplate/TemplateParserSpecs.scala
+++ b/src/test/scala/spray/boilerplate/TemplateParserSpecs.scala
@@ -28,6 +28,9 @@ class TemplateParserSpecs extends Specification {
     "custom range" in {
       parse("[0..14#T1#]") === Expand(LiteralString("T") ~ Offset(1), range = Range(start = Some(0), end = Some(14)))
     }
+    "skipped custom range" in {
+      parse("[!0..14#T1#]") === Skip(LiteralString("T") ~ Offset(1), range = Range(start = Some(0), end = Some(14)))
+    }
     "not a range" in {
       parse("[ abc #T ]") === LiteralString("[ abc #T ]")
     }


### PR DESCRIPTION
This was motivated by my attempt to create a set of "combiner" classes, where each `Combiner{N}` had a method which returned a `Combiner{N+1}`.
```
[2..22#
class Combiner1[[#A1#]]([#v1: A1#]){
  def ~>[B](b: B) = new Combiner2[[#A1#], B]([#v1#], b)
  // plus a handful of actual methods
}
#
]
```

This won't compile because `Combiner22#~>` returns the non-existent `Combiner23` class.

Rather than changing the loop to `2..21` and rewriting `Combiner22` manually, you can now `skip` the `~>` method for iteration 22 by wrapping it in `[!22..#` and `#]`:
```
[2..22#
class Combiner1[[#A1#]]([#v1: A1#]){
  [!22..#def ~>[B](b: B) = new Combiner2[[#A1#], B]([#v1#], b)#]
  // plus a handful of actual methods
}
#
]
```

Coincidentally, this can also be used to create comments in your templates

```
[#A1[!# Hello, template world!#]#]
```