### PR TITLE
Switch groupId from `io.spray` to `com.github.sbt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sbt-boilerplate currently supports sbt 1.x.
 
 Put
 
-    addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.7.0")
+    addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")
 
 into your `plugins.sbt`. sbt-boilerplate is an `AutoPlugin` which needs to be enabled using
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val root = (project in file("."))
   .settings(
     crossScalaVersions := Seq("2.12.18"),
     name := "sbt-boilerplate",
-    organization := "io.spray",
+    organization := "com.github.sbt",
     description := "An SBT plugin for simple generation of boilerplate",
     startYear := Some(2012),
     homepage := Some(url("http://github.com/sbt/sbt-boilerplate")),

--- a/src/sbt-test/sbt-boilerplate/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-boilerplate/simple/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.spray" % "sbt-boilerplate" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % sys.props("project.version"))


### PR DESCRIPTION
The `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` in this GitHub repo's "Repository secrets" don't have permissions to publish to `io.spray` so I guess we need to switch. I will let Scala Steward know of course.