### PR TITLE
fix old `in` syntax warning

### DIFF
--- a/src/main/scala/spray/boilerplate/BoilerplatePlugin.scala
+++ b/src/main/scala/spray/boilerplate/BoilerplatePlugin.scala
@@ -37,7 +37,7 @@ object BoilerplatePlugin extends AutoPlugin {
         boilerplateSource := sourceDirectory.value / "boilerplate",
         boilerplateGeneratedExtension := "scala",
         boilerplateGenerate := generateFromTemplates(streams.value, boilerplateSignature.value, boilerplateSource.value, sourceManaged.value, boilerplateGeneratedExtension.value),
-        mappings in packageSrc ++= managedSources.value pair (Path.relativeTo(sourceManaged.value) | Path.flat),
+        packageSrc / mappings ++= managedSources.value pair (Path.relativeTo(sourceManaged.value) | Path.flat),
         sourceGenerators += boilerplateGenerate)
   }
 


### PR DESCRIPTION
```
[warn] /home/runner/work/sbt-boilerplate/sbt-boilerplate/src/main/scala/spray/boilerplate/BoilerplatePlugin.scala:40:18: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]         mappings in packageSrc ++= managedSources.value pair (Path.relativeTo(sourceManaged.value) | Path.flat),
[warn]                  ^
```